### PR TITLE
Fix type for a few built-in functions

### DIFF
--- a/src/language/expr/builtInFunctions.ts
+++ b/src/language/expr/builtInFunctions.ts
@@ -154,11 +154,11 @@ export const builtInFunctionMatchers = createBuiltInFunctionMatchers(
     .withFunctionName("base64ToString")
     .withParameterCount(1)
     .withParameterTypes(STR)
-    .returnsType(ANY),
+    .returnsType(STR),
   builtInFunctionMatcherFor(stringFunctions.concat)
     .withFunctionName("concat")
     .withParameterCount(atLeast(1))
-    .withParameterTypes(union(INT, STR), rest(union(INT, STR)))
+    .withParameterTypes(union(INT, STR, BOOL), rest(union(INT, STR, BOOL)))
     .returnsType(STR),
   builtInFunctionMatcherFor(stringFunctions.contains)
     .withFunctionName("contains")
@@ -587,7 +587,7 @@ export const builtInFunctionMatchers = createBuiltInFunctionMatchers(
     .withFunctionName("json")
     .withParameterCount(1)
     .withParameterTypes(STR)
-    .returnsType(OBJECT),
+    .returnsType(ANY),
   builtInFunctionMatcherFor(objectFunctions.length)
     .withFunctionName("length")
     .withParameterCount(1)


### PR DESCRIPTION
- Fixed string concat function parameter types
- Fixed return type of base64ToString function
- Fixed return type of json function